### PR TITLE
Fix listing the root directory if the prefix is /

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
   },
   "config": {
     "sort-packages": true
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-main": "1.0.x-dev"
+    }
   }
 }

--- a/src/FlysystemSharepointAdapter.php
+++ b/src/FlysystemSharepointAdapter.php
@@ -268,6 +268,9 @@ class FlysystemSharepointAdapter implements FilesystemAdapter
     }
     
     private function applyPrefix(string $path): string {
+        if($path === '' || $path === '/'){
+            return $this->getPrefix();
+        }
         return sprintf('%s/%s', $this->getPrefix(), ltrim($path));
     }
 }


### PR DESCRIPTION
This change fixes the logic with the prefix application if the prefix is '/' and the root directory is listed (path is "" or "/");